### PR TITLE
Added optional fields with sane defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore default config file for testing
+glauth.cfg
+
+# Ignore the built binary during testing
+glauth

--- a/README.md
+++ b/README.md
@@ -67,6 +67,43 @@ In order to use S3, you must set your AWS credentials.  Either:
 
 More configuration options are documented here: https://github.com/nmcclain/foo/blob/master/sample-simple.cfg
 
+### Required Fields
+ * Name
+   * The user's username
+ * ou
+   * ID of the user's primary group
+ * uidbumber
+   * The user's unix user id
+ * sshPublicKey
+   * Specify an array of public keys
+
+### Optional Fields
+ * givenname
+   * First name
+   * Example: John
+   * default = blank
+ * sn
+   * Last name
+   * Example: Doe
+   * default = blank
+ * disabled
+   * Specify if account is active.
+   * Set to 'true' (without quotes) to make the LDAP entry add 'AccountStatus = inactive'
+   * default = false (active)
+ * mail
+   * Specify an email
+   * example: jdoe@example.com
+   * default = blank
+ * loginshell
+   * Specify a different login shell for the user
+   * Example: /bin/sh, or /sbin/nologin
+   * default = /bin/bash
+ * homedirectory
+   * Specify an overridden home directory for the user
+   * Example: /home/itadmin
+   * default = /home/[username]
+
+
 ### OpenSSH keys:
 GLAuth can store a user's SSH authorized keys.  Add one or more keys per user as shown above, then setup the goklp helper: https://github.com/appliedtrust/goklp
 

--- a/configbackend.go
+++ b/configbackend.go
@@ -156,12 +156,17 @@ func (h configHandler) Search(bindDN string, searchReq ldap.SearchRequest, conn 
 			}
 
 			attrs = append(attrs, &ldap.EntryAttribute{"objectClass", []string{"posixAccount"}})
-			attrs = append(attrs, &ldap.EntryAttribute{"homeDirectory", []string{"/home/" + u.Name}})
 
 			if len(u.LoginShell) > 0 {
 				attrs = append(attrs, &ldap.EntryAttribute{"loginShell", []string{u.LoginShell}})
 			} else {
 				attrs = append(attrs, &ldap.EntryAttribute{"loginShell", []string{"/bin/bash"}})
+			}
+
+			if len(u.Homedir) > 0 {
+				attrs = append(attrs, &ldap.EntryAttribute{"homeDirectory", []string{u.Homedir}})
+			} else {
+				attrs = append(attrs, &ldap.EntryAttribute{"homeDirectory", []string{"/home/" + u.Name}})
 			}
 
 			attrs = append(attrs, &ldap.EntryAttribute{"description", []string{fmt.Sprintf("%s via LDAP", u.Name)}})

--- a/configbackend.go
+++ b/configbackend.go
@@ -132,6 +132,16 @@ func (h configHandler) Search(bindDN string, searchReq ldap.SearchRequest, conn 
 			attrs := []*ldap.EntryAttribute{}
 			attrs = append(attrs, &ldap.EntryAttribute{"cn", []string{u.Name}})
 			attrs = append(attrs, &ldap.EntryAttribute{"uid", []string{u.Name}})
+
+			if len(u.GivenName) > 0 {
+				attrs = append(attrs, &ldap.EntryAttribute{"givenName", []string{u.GivenName}})
+			}
+
+			if len(u.SN) > 0 {
+				attrs = append(attrs, &ldap.EntryAttribute{"sn", []string{u.SN}})
+			}
+
+
 			attrs = append(attrs, &ldap.EntryAttribute{"ou", []string{h.getGroupName(u.PrimaryGroup)}})
 			attrs = append(attrs, &ldap.EntryAttribute{"uidNumber", []string{fmt.Sprintf("%d", u.UnixID)}})
 

--- a/configbackend.go
+++ b/configbackend.go
@@ -141,6 +141,10 @@ func (h configHandler) Search(bindDN string, searchReq ldap.SearchRequest, conn 
 				attrs = append(attrs, &ldap.EntryAttribute{"accountStatus", []string{"active"}})
 			}
 
+			if len(u.Mail) > 0 {
+				attrs = append(attrs, &ldap.EntryAttribute{"mail", []string{u.Mail}})
+			}
+
 			attrs = append(attrs, &ldap.EntryAttribute{"objectClass", []string{"posixAccount"}})
 			attrs = append(attrs, &ldap.EntryAttribute{"homeDirectory", []string{"/home/" + u.Name}})
 			attrs = append(attrs, &ldap.EntryAttribute{"loginShell", []string{"/bin/bash"}})

--- a/configbackend.go
+++ b/configbackend.go
@@ -134,7 +134,13 @@ func (h configHandler) Search(bindDN string, searchReq ldap.SearchRequest, conn 
 			attrs = append(attrs, &ldap.EntryAttribute{"uid", []string{u.Name}})
 			attrs = append(attrs, &ldap.EntryAttribute{"ou", []string{h.getGroupName(u.PrimaryGroup)}})
 			attrs = append(attrs, &ldap.EntryAttribute{"uidNumber", []string{fmt.Sprintf("%d", u.UnixID)}})
-			attrs = append(attrs, &ldap.EntryAttribute{"accountStatus", []string{"active"}})
+
+			if (u.Disabled) {
+				attrs = append(attrs, &ldap.EntryAttribute{"accountStatus", []string{"inactive"}})
+			} else {
+				attrs = append(attrs, &ldap.EntryAttribute{"accountStatus", []string{"active"}})
+			}
+
 			attrs = append(attrs, &ldap.EntryAttribute{"objectClass", []string{"posixAccount"}})
 			attrs = append(attrs, &ldap.EntryAttribute{"homeDirectory", []string{"/home/" + u.Name}})
 			attrs = append(attrs, &ldap.EntryAttribute{"loginShell", []string{"/bin/bash"}})

--- a/configbackend.go
+++ b/configbackend.go
@@ -147,7 +147,13 @@ func (h configHandler) Search(bindDN string, searchReq ldap.SearchRequest, conn 
 
 			attrs = append(attrs, &ldap.EntryAttribute{"objectClass", []string{"posixAccount"}})
 			attrs = append(attrs, &ldap.EntryAttribute{"homeDirectory", []string{"/home/" + u.Name}})
-			attrs = append(attrs, &ldap.EntryAttribute{"loginShell", []string{"/bin/bash"}})
+
+			if len(u.LoginShell) > 0 {
+				attrs = append(attrs, &ldap.EntryAttribute{"loginShell", []string{u.LoginShell}})
+			} else {
+				attrs = append(attrs, &ldap.EntryAttribute{"loginShell", []string{"/bin/bash"}})
+			}
+
 			attrs = append(attrs, &ldap.EntryAttribute{"description", []string{fmt.Sprintf("%s via LDAP", u.Name)}})
 			attrs = append(attrs, &ldap.EntryAttribute{"gecos", []string{fmt.Sprintf("%s via LDAP", u.Name)}})
 			attrs = append(attrs, &ldap.EntryAttribute{"gidNumber", []string{fmt.Sprintf("%d", u.PrimaryGroup)}})

--- a/glauth.go
+++ b/glauth.go
@@ -77,6 +77,8 @@ type configUser struct {
 	UnixID       int
 	Mail         string
 	LoginShell   string
+	GivenName    string
+	SN           string
 }
 type configGroup struct {
 	Name   string

--- a/glauth.go
+++ b/glauth.go
@@ -76,6 +76,7 @@ type configUser struct {
 	Disabled     bool
 	UnixID       int
 	Mail         string
+	LoginShell   string
 }
 type configGroup struct {
 	Name   string

--- a/glauth.go
+++ b/glauth.go
@@ -73,6 +73,7 @@ type configUser struct {
 	PassSHA256   string
 	PrimaryGroup int
 	SSHKeys      []string
+	Disabled     bool
 	UnixID       int
 }
 type configGroup struct {

--- a/glauth.go
+++ b/glauth.go
@@ -79,6 +79,7 @@ type configUser struct {
 	LoginShell   string
 	GivenName    string
 	SN           string
+	Homedir      string
 }
 type configGroup struct {
 	Name   string

--- a/glauth.go
+++ b/glauth.go
@@ -75,6 +75,7 @@ type configUser struct {
 	SSHKeys      []string
 	Disabled     bool
 	UnixID       int
+	Mail         string
 }
 type configGroup struct {
 	Name   string


### PR DESCRIPTION
Added a number of optional fields:

- disabled - set to 'true' to mark an account as inactive. Default = active
- givenname and sn - specify first and lastname. Default = not included in query response
- mail - specify email. Default = not included in query response
- loginshell - specify login shell. Default = /bin/bash

Be patient with me, this is my first overture into writing go! Let me know if there's a better way to handle this.

In particular, it might be nice to add an abstraction for default values instead of a row of IFs. Perhaps it might even be useful to implement a freeform option, which can allow the config file to add arbitrary LDAP attributes.

Because of the sane defaults, this should be fully backwards compatible. 